### PR TITLE
make sure social button's svgs are visible

### DIFF
--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -173,6 +173,7 @@
       svg {
         width: 100%;
         max-height: 24px;
+        overflow: visible;
       }
 
       &_vk {


### PR DESCRIPTION
When using this plugin along with standard css resets, the svgs are not visible on buttons. Setting that to overflow: visible makes sure they show up.