### PR TITLE
make sure social svgs are visible

### DIFF
--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -171,7 +171,7 @@
       @include iconHover();
 
       svg {
-        width: 100%;
+        overflow: visible;
         max-height: 24px;
       }
 


### PR DESCRIPTION
When users has a standard reset.css or other files impacting layout, svgs may not display in the buttons.