### PR TITLE
es6 dependency fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,9 +68,6 @@
   "eslintConfig": {
     "env": {
       "browser": true
-    },
-    "globals": {
-      "videojs": {}
     }
   },
   "dependencies": {

--- a/src/ShareButton.js
+++ b/src/ShareButton.js
@@ -1,3 +1,4 @@
+import videojs from 'video.js';
 const Button = videojs.getComponent('Button');
 
 /**

--- a/src/ShareModal.js
+++ b/src/ShareModal.js
@@ -1,3 +1,4 @@
+import videojs from 'video.js';
 const ModalDialog = videojs.getComponent('ModalDialog');
 
 /**

--- a/src/ShareModalContent.js
+++ b/src/ShareModalContent.js
@@ -1,5 +1,5 @@
-import Clipboard from 'clipboard';
-import * as sharing from 'vanilla-sharing';
+const Clipboard = require('clipboard');
+const sharing = require('vanilla-sharing');
 
 import { isTouchDevice, filterSocials } from './utils';
 
@@ -109,7 +109,7 @@ export default class ShareModalContent {
             ${copyBtn}
           </div>
         </div>
-        
+
         ${embedContainer}
       </div>
 
@@ -153,9 +153,10 @@ export default class ShareModalContent {
     Array.from(btns).forEach((btn) => {
       btn.addEventListener('click', (e) => {
         const social = e.currentTarget.getAttribute('data-social');
+        const sharingFN = sharing[social];
 
-        if (typeof sharing[social] === 'function') {
-          sharing[social](this.socialOptions);
+        if (typeof sharingFN === 'function') {
+          sharingFN(this.socialOptions);
         }
       });
     });

--- a/src/ShareOverlay.js
+++ b/src/ShareOverlay.js
@@ -1,6 +1,6 @@
-import ShareModal from './ShareModal';
 import ShareModalContent from './ShareModalContent';
-
+import ShareModal from './ShareModal';
+import videojs from 'video.js';
 const Component = videojs.getComponent('Component');
 
 /**


### PR DESCRIPTION
Changes:
- Adds explicit videojs imports.
- The global `videojs`  was causing a missing reference error when building with webpack 4.
- Stops treating clipboard and vanilla-sharing as external dependencies.

When I was building the module for some local testing I noticed that `clipboard` and vanilla sharing were not included in the output bundle and the following warning was being printed to the console. 
<img width="953" alt="screenshot 2019-02-27 12 06 50" src="https://user-images.githubusercontent.com/2947203/53505513-59eb4700-3a8a-11e9-8a34-b4d01b508b3d.png">

This seems to be caused due to no `es` module support on these packages

<img width="247" alt="screenshot 2019-02-27 12 08 43" src="https://user-images.githubusercontent.com/2947203/53505620-95861100-3a8a-11e9-9ceb-a5dcc684b57e.png">
<img width="283" alt="screenshot 2019-02-27 12 09 26" src="https://user-images.githubusercontent.com/2947203/53505622-95861100-3a8a-11e9-9dcd-2b04804080fa.png">

So to resolve this I changed the syntax from `import` to `require` which solved the issue but I dont know if its the best way to go about it.

https://github.com/mkhazov/videojs-share/blob/8f1b8aabd19ba33c9fbf442a3fef2387d2bebab9/src/ShareModalContent.js#L1-L2