### PR TITLE
feat: adding support to mobile device events

### DIFF
--- a/src/ShareModalContent.js
+++ b/src/ShareModalContent.js
@@ -1,6 +1,6 @@
 import Clipboard from 'clipboard';
 import * as sharing from 'vanilla-sharing';
-import { isTouchDevice, filterSocials } from './utils';
+import { isTouchDevice, filterSocials, getEventByContext } from './utils';
 import fbFeed from './icons/fbFeed.svg';
 import tw from './icons/tw.svg';
 import reddit from './icons/reddit.svg';
@@ -151,7 +151,10 @@ export default class ShareModalContent {
     const btns = this.content.querySelectorAll(`.${this.socialBtnClass}`);
 
     Array.from(btns).forEach((btn) => {
-      btn.addEventListener('click', (e) => {
+      
+      const eventByContext = getEventByContext()
+
+      btn.addEventListener(eventByContext, (e) => {
         const social = e.currentTarget.getAttribute('data-social');
         const sharingFN = sharing[social];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,3 +32,12 @@ export function filterSocials(socials = [], mobileVerification = true) {
     isMobileDevice() ? socials : socials.filter((social) => !EXCLUDED_SOCIALS.includes(social)) :
     socials;
 }
+
+/**
+ * Checks which event is to be used.
+ * 
+ * @return {boolean}
+ */
+export function getEventByContext() {
+  return (isMobileDevice() ? 'touchend' : 'click'); 
+}


### PR DESCRIPTION
In some mobile devices the click event is no triggered properly when interacting with the button, thus not firing the share option, by using a touchend event it ensures that the share event is triggered on mobile devices too